### PR TITLE
Added a sample mesh to Implement Custom Fields in Commerce

### DIFF
--- a/api-mesh/custom-field/README.md
+++ b/api-mesh/custom-field/README.md
@@ -1,0 +1,63 @@
+# API Mesh Configuration with Custom Resolver
+## Implementing a Custom Field in API Mesh
+
+This is an example API Mesh configuration that demonstrates how to extend the GraphQL Query type with a custom field and add a resolver to connect it to an existing source.
+
+In this example, we will connect the Commerce Source with the Announcements Source and implement an announcement field on the storeConfig.
+
+## Table of Contents
+
+- [Configuration](#configuration)
+
+## Configuration
+
+Here's the GraphQL Mesh configuration used in this example:
+
+```json
+{
+  "meshConfig": {
+    "sources": [
+      {
+        "name": "CommerceAPI",
+        "handler": {
+          "graphql": {
+            "endpoint": "https://venia.magento.com/graphql/",
+            "useGETForQueries": true,
+            "operationHeaders": {
+              "Content-Type": "application/json",
+              "Store": "{context.headers['store']}",
+              "Authorization": "context.headers['Authorization']"
+            }
+          }
+        }
+      },
+      {
+        "name": "Announcements",
+        "handler": {
+          "JsonSchema": {
+            "baseUrl": "https://announcements-api.apimesh-adobe-test.workers.dev",
+            "operations": [
+              {
+                "type": "Query",
+                "field": "announcements",
+                "path": "/",
+                "method": "GET",
+                "responseSample": "./samplesAnnouncement.json"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "additionalTypeDefs": "extend type StoreConfig {announcement: String}",
+    "additionalResolvers": ["./resolvers.js"]
+  }
+}
+
+```
+
+### Explanation
+
+- **sources**: Defines the external GraphQL API to be included in the mesh. In this example, we are using the Adobe Commerce GraphQL endpoint.
+- **additionalTypeDefs**: Extends the existing GraphQL schema by adding a new field `announcement` to the StoreConfig type.
+- **additionalResolvers**: Points to a resolver file that contains the logic to resolve the `announcement` on the StoreConfig type.

--- a/api-mesh/custom-field/README.md
+++ b/api-mesh/custom-field/README.md
@@ -9,6 +9,8 @@ In this example, we will connect the Commerce Source with the Announcements Sour
 ## Table of Contents
 
 - [Configuration](#configuration)
+- [Explanation](#explanation)
+- [Verification Steps](#verification-steps)
 
 ## Configuration
 
@@ -22,7 +24,7 @@ Here's the GraphQL Mesh configuration used in this example:
         "name": "CommerceAPI",
         "handler": {
           "graphql": {
-            "endpoint": "https://venia.magento.com/graphql/",
+            "endpoint": "{{env.COMMERCE_ENDPOINT}}",
             "useGETForQueries": true,
             "operationHeaders": {
               "Content-Type": "application/json",
@@ -36,14 +38,14 @@ Here's the GraphQL Mesh configuration used in this example:
         "name": "Announcements",
         "handler": {
           "JsonSchema": {
-            "baseUrl": "https://announcements-api.apimesh-adobe-test.workers.dev",
+            "baseUrl": "{{env.ANNOUNCEMENTS_ENDPOINT}}",
             "operations": [
               {
                 "type": "Query",
                 "field": "announcements",
                 "path": "/",
                 "method": "GET",
-                "responseSample": "./samplesAnnouncement.json"
+                "responseSample": "{{env.ANNOUNCEMENTS_ENDPOINT}}"
               }
             ]
           }
@@ -56,7 +58,9 @@ Here's the GraphQL Mesh configuration used in this example:
 }
 ```
 
-### Explanation
+Note: This mesh depends on few variables which need to be provided through `.env`. A [sample env file](./sample.env) has been provided to get started.
+
+## Explanation
 
 - **sources**: Defines the external GraphQL API to be included in the mesh. In this example, we are using the Adobe Commerce GraphQL endpoint.
 - **additionalTypeDefs**: Extends the existing GraphQL schema by adding a new field `announcement` to the StoreConfig type.

--- a/api-mesh/custom-field/README.md
+++ b/api-mesh/custom-field/README.md
@@ -1,4 +1,5 @@
 # API Mesh Configuration with Custom Resolver
+
 ## Implementing a Custom Field in API Mesh
 
 This is an example API Mesh configuration that demonstrates how to extend the GraphQL Query type with a custom field and add a resolver to connect it to an existing source.
@@ -53,7 +54,6 @@ Here's the GraphQL Mesh configuration used in this example:
     "additionalResolvers": ["./resolvers.js"]
   }
 }
-
 ```
 
 ### Explanation
@@ -61,3 +61,17 @@ Here's the GraphQL Mesh configuration used in this example:
 - **sources**: Defines the external GraphQL API to be included in the mesh. In this example, we are using the Adobe Commerce GraphQL endpoint.
 - **additionalTypeDefs**: Extends the existing GraphQL schema by adding a new field `announcement` to the StoreConfig type.
 - **additionalResolvers**: Points to a resolver file that contains the logic to resolve the `announcement` on the StoreConfig type.
+
+## Verification Steps
+
+Create a mesh with the above config and resolver. Run the following command to verify:
+
+```graphql
+{
+  storeConfig {
+    announcement
+  }
+}
+```
+
+<img width="1303" alt="image" src="https://github.com/adobe/adobe-commerce-samples/assets/35203638/fce4ebea-05a7-483e-966e-543790c45080">

--- a/api-mesh/custom-field/meshConfig.json
+++ b/api-mesh/custom-field/meshConfig.json
@@ -1,0 +1,39 @@
+{
+  "meshConfig": {
+    "sources": [
+      {
+        "name": "CommerceAPI",
+        "handler": {
+          "graphql": {
+            "endpoint": "https://venia.magento.com/graphql/",
+            "useGETForQueries": true,
+            "operationHeaders": {
+              "Content-Type": "application/json",
+              "Store": "{context.headers['store']}",
+              "Authorization": "context.headers['Authorization']"
+            }
+          }
+        }
+      },
+      {
+        "name": "Announcements",
+        "handler": {
+          "JsonSchema": {
+            "baseUrl": "https://announcements-api.apimesh-adobe-test.workers.dev",
+            "operations": [
+              {
+                "type": "Query",
+                "field": "announcements",
+                "path": "/",
+                "method": "GET",
+                "responseSample": "./samplesAnnouncement.json"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "additionalTypeDefs": "extend type StoreConfig {announcement: String}",
+    "additionalResolvers": ["./resolvers.js"]
+  }
+}

--- a/api-mesh/custom-field/meshConfig.json
+++ b/api-mesh/custom-field/meshConfig.json
@@ -26,7 +26,7 @@
                 "field": "announcements",
                 "path": "/",
                 "method": "GET",
-                "responseSample": "./samplesAnnouncement.json"
+                "responseSample": "https://announcements-api.apimesh-adobe-test.workers.dev"
               }
             ]
           }

--- a/api-mesh/custom-field/meshConfig.json
+++ b/api-mesh/custom-field/meshConfig.json
@@ -5,7 +5,7 @@
         "name": "CommerceAPI",
         "handler": {
           "graphql": {
-            "endpoint": "https://venia.magento.com/graphql/",
+            "endpoint": "{{env.COMMERCE_ENDPOINT}}",
             "useGETForQueries": true,
             "operationHeaders": {
               "Content-Type": "application/json",
@@ -19,14 +19,14 @@
         "name": "Announcements",
         "handler": {
           "JsonSchema": {
-            "baseUrl": "https://announcements-api.apimesh-adobe-test.workers.dev",
+            "baseUrl": "{{env.ANNOUNCEMENTS_ENDPOINT}}",
             "operations": [
               {
                 "type": "Query",
                 "field": "announcements",
                 "path": "/",
                 "method": "GET",
-                "responseSample": "https://announcements-api.apimesh-adobe-test.workers.dev"
+                "responseSample": "{{env.ANNOUNCEMENTS_ENDPOINT}}"
               }
             ]
           }

--- a/api-mesh/custom-field/resolvers.js
+++ b/api-mesh/custom-field/resolvers.js
@@ -1,0 +1,36 @@
+/*
+Copyright 2024 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+module.exports = {
+  resolvers: {
+    StoreConfig: {
+      announcement: {
+        selectionSet: "{store_code}",
+        resolve: (root, args, context, info) => {
+          return context.Announcements.Query.announcements({
+            root,
+            args,
+            context,
+            info,
+            selectionSet: "{announcement}",
+          })
+            .then((response) => {
+              return response.announcement;
+            })
+            .catch(() => {
+              return null;
+            });
+        },
+      },
+    },
+  },
+};

--- a/api-mesh/custom-field/resolvers.js
+++ b/api-mesh/custom-field/resolvers.js
@@ -12,21 +12,27 @@ governing permissions and limitations under the License.
 
 module.exports = {
   resolvers: {
+    // Selecting the `StoreConfig` type.
     StoreConfig: {
+      // Selecting the `announcement` field on the `StoreConfig` type to add a resolver.
       announcement: {
         selectionSet: "{store_code}",
+        // This resolver is called when the `announcement` field is requested on the `StoreConfig` type.
         resolve: (root, args, context, info) => {
+          // Call the `announcements` query from the `Announcements` source to get the latest announcement.
           return context.Announcements.Query.announcements({
             root,
             args,
             context,
             info,
-            selectionSet: "{announcement}",
+            selectionSet: "{announcement}", // Selecting the `announcement` field from the response.
           })
             .then((response) => {
+              // Return the announcement from the response.
               return response.announcement;
             })
             .catch(() => {
+              // Return null if there is an error.
               return null;
             });
         },

--- a/api-mesh/custom-field/sample.env
+++ b/api-mesh/custom-field/sample.env
@@ -1,0 +1,2 @@
+COMMERCE_ENDPOINT="https://venia.magento.com/graphql/"
+ANNOUNCEMENTS_ENDPOINT="https://announcements-api.apimesh-adobe-test.workers.dev"


### PR DESCRIPTION
## Description

This example shows how to implement a custom field on the commerce source. It uses a sample announcements API and connects to the a custom field called `announcement` on the `StoreConfig` type.

## Related Issue

NA

## Motivation and Context

Show how to create and define custom fields on API Mesh.

## How Has This Been Tested?

Create a mesh with the given config and resolvers. Run the following command to verify:

```graphql
{
  storeConfig {
    announcement
  }
}
```

## Screenshots (if appropriate):

<img width="1303" alt="image" src="https://github.com/adobe/adobe-commerce-samples/assets/35203638/fce4ebea-05a7-483e-966e-543790c45080">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
