### PR TITLE
Adds missing import from react

### DIFF
--- a/admin-ui-sdk/menu/custom-menu/src/commerce-backend-ui-1/web-src/src/components/MainPage.js
+++ b/admin-ui-sdk/menu/custom-menu/src/commerce-backend-ui-1/web-src/src/components/MainPage.js
@@ -23,6 +23,7 @@ import { Orders } from './Orders'
 import { Products } from './Products'
 import { useState } from 'react'
 import { extensionId } from './Constants'
+import { useEffect } from 'react'
 
 export const MainPage = props => {
 

--- a/admin-ui-sdk/menu/custom-menu/src/commerce-backend-ui-1/web-src/src/components/MainPage.js
+++ b/admin-ui-sdk/menu/custom-menu/src/commerce-backend-ui-1/web-src/src/components/MainPage.js
@@ -21,9 +21,8 @@ import {
 import { attach } from '@adobe/uix-guest'
 import { Orders } from './Orders'
 import { Products } from './Products'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { extensionId } from './Constants'
-import { useEffect } from 'react'
 
 export const MainPage = props => {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Added missing `useEffect` import from React

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

This change fixes a runtime JavaScript error that was preventing the CustomMenu extension from loading properly. The error "useEffect is not defined" was occurring because the React `useEffect` hook was being used but wasn't imported.


## How Has This Been Tested?

Functional tests were done to ensure the CustomMenu extension was running successfully.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
