### PR TITLE
CEXT-6400: Add Renovate config scoped to admin-ui-sdk/v2 samples

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices",
+    "config:recommended",
+    "customManagers:biomeVersions",
+    "group:recommended",
+    "group:monorepos",
+    "group:definitelyTyped",
+    "helpers:disableTypesNodeMajor",
+    "helpers:pinGitHubActionDigestsToSemver",
+    "security:minimumReleaseAgeNpm",
+    ":automergeDisabled",
+    ":ignoreUnstable",
+    ":prConcurrentLimitNone",
+    ":preserveSemverRanges",
+    ":rebaseStalePrs",
+    ":renovatePrefix",
+    ":updateNotScheduled",
+    ":separateMultipleMajorReleases"
+  ],
+  "includePaths": ["admin-ui-sdk/v2/**"],
+  "automerge": false,
+  "vulnerabilityAlerts": {
+    "automerge": true
+  },
+  "osvVulnerabilityAlerts": true,
+  "branchPrefix": "renovate/",
+  "commitMessagePrefix": "RENOVATE: ",
+  "labels": ["dependencies"],
+  "postUpdateOptions": ["npmDedupe"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/\\.config\\.yaml$/"],
+      "matchStrings": ["runtime: ['\"]?nodejs:(?<currentValue>\\d+)['\"]?"],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "node"
+    }
+  ],
+  "packageRules": [
+    {
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-non-major",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "schedule": ["on Monday"]
+    },
+    {
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "automerge": true,
+      "schedule": ["on Monday"]
+    },
+    {
+      "groupName": "aio-commerce-sdk",
+      "matchPackageNames": [
+        "@adobe/aio-commerce-lib-*",
+        "@adobe/aio-commerce-sdk*"
+      ],
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Adds `.github/renovate.json`, based on the Renovate config used in `adobe/commerce-checkout-starter-kit`, restricted via `includePaths` to only the `admin-ui-sdk/v2/**` samples so dependency updates don't touch v1 samples or any other sample directory in the repo.

## Related Issue

N/A

## Motivation and Context

The repo has no automated dependency updates for npm packages today (the existing `.github/dependabot.yml` only covers devcontainers). Keeping the newly added Admin UI SDK v2 samples current with `@adobe/aio-commerce-lib-app` and `@adobe/aio-commerce-sdk` releases needs automation, without expanding scope to the rest of the repo's samples.

## How Has This Been Tested?

Validated the config with `renovate-config-validator` (`npx -p renovate renovate-config-validator .github/renovate.json`), which passed successfully.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.